### PR TITLE
feat: schedule created

### DIFF
--- a/src/main/java/com/trabalho/api/autores_livros/AutoresLivrosApplication.java
+++ b/src/main/java/com/trabalho/api/autores_livros/AutoresLivrosApplication.java
@@ -2,7 +2,9 @@ package com.trabalho.api.autores_livros;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class AutoresLivrosApplication {
 
@@ -11,3 +13,6 @@ public class AutoresLivrosApplication {
 	}
 
 }
+
+
+

--- a/src/main/java/com/trabalho/api/autores_livros/models/Livro.java
+++ b/src/main/java/com/trabalho/api/autores_livros/models/Livro.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Data
 @Entity
@@ -20,9 +22,10 @@ public class Livro {
     private Integer ano;
 
     @ManyToOne
-    @JoinColumn(name = "autor_id")
-    @NotNull(message = "O autor é obrigatório")
+    @JoinColumn(name = "autor_id", nullable = true)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
     private Autor autor;
-
 }
+
+
 

--- a/src/main/java/com/trabalho/api/autores_livros/repositories/LivroRepository.java
+++ b/src/main/java/com/trabalho/api/autores_livros/repositories/LivroRepository.java
@@ -4,5 +4,9 @@ package com.trabalho.api.autores_livros.repositories;
 import com.trabalho.api.autores_livros.models.Livro;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LivroRepository extends JpaRepository<Livro, Long> {
+
+    List<Livro> findByAutorIsNull();
 }

--- a/src/main/java/com/trabalho/api/autores_livros/schedule/TarefasAgendadas.java
+++ b/src/main/java/com/trabalho/api/autores_livros/schedule/TarefasAgendadas.java
@@ -1,0 +1,28 @@
+package com.trabalho.api.autores_livros.schedule;
+
+import com.trabalho.api.autores_livros.models.Livro;
+import com.trabalho.api.autores_livros.repositories.LivroRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+    @Component
+    public class TarefasAgendadas {
+
+        @Autowired
+        private LivroRepository livroRepository;
+
+        @Scheduled(fixedRate = 60000)
+        public void removerLivrosOrfaos() {
+            System.out.println("SCHEDULE RODANDO...");
+            List<Livro> livrosOrfaos = livroRepository.findByAutorIsNull();
+
+            if (!livrosOrfaos.isEmpty()) {
+                livroRepository.deleteAll(livrosOrfaos);
+                System.out.println("Livros órfãos removidos: " + livrosOrfaos.size());
+            }
+        }
+    }
+


### PR DESCRIPTION
Limpeza automática de livros órfãos com agendamento

Foi implementada uma rotina automática utilizando o @Scheduled do Spring Framework para garantir a integridade dos dados entre as entidades Autor e Livro, sem depender de requisições HTTP.

Objetivo

Evitar que permaneçam no banco registros de Livro sem um Autor válido (registros órfãos), situação que pode ocorrer após a exclusão de um autor.

Como funciona
O relacionamento Livro → Autor foi configurado para permitir SET NULL na chave estrangeira quando um autor é removido.
Foi criado um componente agendado (TarefasAgendadas) responsável por executar periodicamente uma verificação no banco.
A cada intervalo definido, o sistema busca livros cujo autor_id esteja NULL.
Caso existam, esses livros são removidos automaticamente.
Configurações realizadas
Ativação do agendamento com @EnableScheduling na classe principal.
Criação do pacote schedule contendo a classe responsável pelas tarefas agendadas.
Método no LivroRepository: findByAutorIsNull().
Ajuste do mapeamento em Livro para permitir que a FK fique nula após a exclusão do autor.
Resultado

Após a exclusão de um autor via endpoint:

Os livros associados permanecem temporariamente com autor_id = NULL.
Sem qualquer nova requisição, o processo agendado identifica esses registros.
Os livros órfãos são excluídos automaticamente.

Essa implementação demonstra o uso de processos internos da aplicação executados no tempo, garantindo consistência do banco de dados de forma autônoma.